### PR TITLE
Obvious error — incorrect connection string, lost port information…

### DIFF
--- a/pylib/dbx_psycopg.py
+++ b/pylib/dbx_psycopg.py
@@ -102,8 +102,8 @@ class Connection(object):
             parts.append("password='%s'" % self.password)
         if self.host and self.host != 'localhost':
             parts.append("host='%s'" % self.host)
-            if self.password:
-                parts.append("password='%s'" % self.password)
+        if self.port:
+            parts.append("port='%s'" % self.port)
         return " ".join(parts)
 
     def getConnectionDisplayValues(self):


### PR DESCRIPTION
Obvious error — incorrect connection string, lost port information. And port should be set even for localhost
